### PR TITLE
remove rock island specific text from magwest

### DIFF
--- a/magwest/templates/bands/agreement.html
+++ b/magwest/templates/bands/agreement.html
@@ -1,0 +1,5 @@
+{% extends "bands/agreement-base.html" %}
+
+{% block band_text_merch_inner %}
+Space will be provided at the event for merchandise sales.  On the night of the performance, optional table space will also be provided immediately in or near the concert hall for merchandise sales and signings.
+{% endblock %}


### PR DESCRIPTION
override text in magwest band plugin that references Rock Island with some text that doesn't

by request of Gene, west music DH.