### PR TITLE
Adds PC Gaming Survey AutomatedEmail() for attendees who are interested in LAN

### DIFF
--- a/magwest/automated_emails.py
+++ b/magwest/automated_emails.py
@@ -9,14 +9,23 @@ AutomatedEmail(Attendee, '{EVENT_NAME} food for guests', 'guest_food_restriction
            lambda a: a.badge_type == c.GUEST_BADGE,
            ident='magwest_guest_food_restrictions',
            sender="MAGFest Staff Suite <chefs@magfest.org>")
+
 AutomatedEmail(Attendee, '{EVENT_NAME} hospitality suite information', 'guest_food_info.txt',
            lambda a: a.badge_type == c.GUEST_BADGE,
            ident='magwest_guest_food_info',
            sender="MAGFest Staff Suite <chefs@magfest.org>")
+
 AutomatedEmail(Attendee, '{EVENT_NAME} Volunteer Food', 'volunteer_food_info.txt',
            lambda a: a.staffing and days_before(7, c.FINAL_EMAIL_DEADLINE),
            ident='magwest_volunteer_food_info',
            sender="MAGFest Staff Suite <chefs@magfest.org>")
+
 AutomatedEmail(Attendee, '{EVENT_NAME} FAQ', 'prefest_faq.html',
                lambda a: a.badge_status == c.COMPLETED_STATUS and days_before(7, c.FINAL_EMAIL_DEADLINE),
                ident='magwest_prefest_faq')
+
+AutomatedEmail(Attendee, '{EVENT_NAME} PC Gaming Survey', 'pc_gaming_survey.html',
+           lambda a: c.LAN in a.interests_ints,
+           ident='pc_gaming_survey',
+           needs_approval=True,
+           sender="MAGWest LAN Staff <lan@magwest.org>")

--- a/magwest/templates/emails/pc_gaming_survey.html
+++ b/magwest/templates/emails/pc_gaming_survey.html
@@ -1,0 +1,43 @@
+<html>
+<head></head>
+<body>
+
+{{ attendee.first_name }},
+<br/> <br/>
+
+You are receiving this email because you ticked an interest in <i>PC Gaming</i>
+(LAN) while pre-registering for {{ c.EVENT_NAME }}. We have a quick survey for
+those interested in BYOC to help us make sure we have things dialed in for
+opening day.
+<br /><br />
+<b><u>SURVEY</u></b>
+<br /><br />
+<a href="https://goo.gl/forms/DAzL6PO4OuVAeqAf2">https://goo.gl/forms/DAzL6PO4OuVAeqAf2</a>
+<br /><br />
+We'll send out a second email right before the event for those that have fill
+out the survey, with all the final details including a tournament list.
+<br/> <br/>
+<b><u>WANT TO HELP?</u></b>
+<br/> <br/>
+We're always looking for new staffers and volunteers to help us run the PC
+Gaming areas. Got experience in commentating live games? Want to help set up
+the network prior to the event starting? Want to run a few tournaments? Let us
+know! Email us at lan@magwest.org and tell us you’d like to help out!
+<br/><br/>
+Also, If you have a spare PC and would like to let us borrow it for public
+play, we'd be super appreciative. Contact us at lan@magwest.org and we'll hook
+you up with the deets (and maybe more).
+<br/> <br/> <hr/> <br/> <br/>
+
+Feel free to to send us an e-mail at lan@magwest.org with any questions,
+comments or concerns.
+<br/> <br/>
+Thank you again for having interest in the {{ c.EVENT_NAME }} LAN room and
+we'll see you on {{ c.EPOCH|datetime_local("%B %e, %Y") }}!
+<br/> <br/>
+With love, <br/>
+{{ c.EVENT_NAME }} LAN Staff</br>
+{{ event_dates() }} - {{ c.EVENT_NAME }} {{ c.EVENT_YEAR }} BYOC LAN / PC Gaming Room
+
+</body>
+</html>


### PR DESCRIPTION
Per request from gamma in Slack.

Original email text from [here](https://gist.github.com/gammasts/ba474aa2107676506e73cf3921e0dc27):

```
<html>
<head></head>
<body>

{{ attendee.first_name }},
<br/> <br/>

You are receiving this email because you ticked an interest in <i>PC Gaming</i> (LAN) while pre-registering for MAGWest. We have a quick survey for those interested in BYOC to help us make sure we have things dialed in for opening day.
<br /><br />
<b><u>SURVEY</u></b>
<br /><br />
<a href="https://goo.gl/forms/DAzL6PO4OuVAeqAf2">https://goo.gl/forms/DAzL6PO4OuVAeqAf2</a>
<br /><br />
We'll send out a second email right before the event for those that have fill out the survey, with all the final details including a tournament list.
<br/> <br/>
<b><u>WANT TO HELP?</u></b>
<br/> <br/>
We're always looking for new staffers and volunteers to help us run the PC Gaming areas. Got experience in commentating live games? Want to help set up the network prior to the event starting? Want to run a few tournaments? Let us know! Email us at lan@magwest.org and tell us you’d like to help out!
<br/><br/>
  Also, If you have a spare PC and would like to let us borrow it for public play, we'd be super appreciative. Contact us at lan@magwest.org and we'll hook you up with the deets (and maybe more).
<br/> <br/> <hr/> <br/> <br/>

Feel free to to send us an e-mail at lan@magwest.org with any questions, comments or concerns.
<br/> <br/>
Thank you again for having interest in the MAGWest LAN room and we'll see you on August 25th, 2017!
<br/> <br/>
With love, <br/>
MAGWest LAN Staff</br>
Aug 25th - 27th 2017 - MAGWest 2017 BYOC LAN / PC Gaming Room

</body>
</html>
```