### PR TITLE
Update MAGWest disclaimer with new links and styling

### DIFF
--- a/magwest/templates/preregistration/disclaimers.html
+++ b/magwest/templates/preregistration/disclaimers.html
@@ -1,19 +1,18 @@
 
-<hr/>
-
-<div style="font-weight:bold ; color:red ; margin-bottom:5px">Disclaimers:</div>
+<h4 class="text-danger">Disclaimers</h4>
 <ul>
-    <li> Please review our badge polices and other <a href="http://magwest.org/faq">frequently asked questions</a> prior to purchasing your badge for important information. </li> 
-    <li> If you don't pay for your registration, it will be deleted and you will have to pay full price at the door. </li> 
-    <li> Your registration is <a href="http://magwest.org/faq">non-refundable</a> but may be <a href="http://magwest.org/faq">sold/transferred</a>. </li> 
-    <li> MAGFest has a <a href="http://magwest.org/faq">one badge per person policy</a>. If you purchase multiple badges (for your family, as a gift), please ensure that each badge is purchased in the name of the individual who the badge is intended for. You may use the same email address for multiple badges so any surprises aren't ruined. </li> 
-    <li> Attendees (including dealers) must abide by our <a href="http://magwest.org/codeofconduct">code of conduct</a>. </li> 
-    {% if c.CONSENT_FORM_URL %}
-        <li> Attendees under 18 MUST bring a <a href="http://www.magfest.org/parentalconsentform">signed parental consent form</a>, which MUST be notarized if the parent is not with the minor when the badge is picked up. Also, All children 12 and under will need to be accompanied by an adult with a paid badge. </li> 
-    {% endif %}
-    {% if c.DEALER_REG_START %}
-        <li> Submitting this form as a Dealer does not guarantee you will be selected for the Dealers Room - it is only the application. </li> 
-    {% endif %}
+  <li>This is a one-time non-recurring payment. This is not a subscription service.</li>
+  <li> Please review our badge polices and other <a href="http://magwest.org/faq" target="_faq">frequently asked questions</a> prior to purchasing your badge for important information. </li>
+  <li> If you don't pay for your registration, it will be deleted and you will have to pay full price at the door. </li>
+  <li> Your registration is <a href="http://magwest.org/faq" target="_faq">non-refundable</a> but may be <a href="http://magwest.org/faq#badge-transfer" target="_faq">sold/transferred</a>. </li>
+  <li> MAGFest has a <a href="http://magwest.org/faq" target="_faq#badge-for-someone-else">one badge per person policy</a>. If you purchase multiple badges (for your family, as a gift), please ensure that each badge is purchased in the name of the individual who the badge is intended for. You may use the same email address for multiple badges so any surprises aren't ruined. </li>
+  <li> Attendees (including dealers) must abide by our <a href="https://www.magwest.org/code-of-conduct" target="_coc">code of conduct</a>. </li>
+  {% if c.CONSENT_FORM_URL %}
+    <li> Attendees under 18 MUST bring a <a href="http://www.magfest.org/parentalconsentform" target="_pcf">signed parental consent form</a>, which MUST be notarized if the parent is not with the minor when the badge is picked up. Also, All children 12 and under will need to be accompanied by an adult with a paid badge. </li>
+  {% endif %}
+  {% if c.DEALER_REG_START %}
+    <li> Submitting this form as a Dealer does not guarantee you will be selected for the Dealers Room - it is only the application. </li>
+  {% endif %}
 </ul>
 <br/>
 


### PR DESCRIPTION
Addresses part of https://jira.magfest.net/browse/MAGDEV-430 and fixes https://jira.magfest.net/browse/MAGDEV-436.

... I accidentally updated all the whitespace, sorry about the hard-to-read diff.