### PR TITLE
Remove badge printed name fields

### DIFF
--- a/magwest/templates/regextra.html
+++ b/magwest/templates/regextra.html
@@ -5,6 +5,9 @@
             if ($(".badge-type-selector").size()) {
                 $(".badge-type-selector").parents('.form-group').hide();
             }
+            if ($.field('badge_printed_name').size()) {
+                $.field('badge_printed_name').parents('.form-group').remove();
+            }
         })
     }
 </script>


### PR DESCRIPTION
Fixes https://jira.magfest.net/browse/MAGDEV-441. Luckily, past-us had the foresight to not actually require a printed badge name, so taking it out is just a matter of ripping it out of the templates with the magic of jQuery.