### PR TITLE
Create West-specific dealer confirmation page & email

### DIFF
--- a/magwest/templates/emails/dealers/application.html
+++ b/magwest/templates/emails/dealers/application.html
@@ -1,0 +1,44 @@
+<html>
+<head></head>
+<body>
+
+Your group ({{ group.name }}) has successfully submitted a Dealer application for {{ c.EVENT_NAME }}
+this coming {{ event_dates() }}. Below is a copy of your application. You may
+<a href="{{ c.URL_BASE }}/preregistration/group_members?id={{ group.id }}">update it here</a> or
+<a href="{{ c.URL_BASE }}/preregistration/confirm?id={{ group.leader.id }}">view your badge here</a>.
+<ul>
+    <li><strong>Dealer Table Name</strong>: {{ group.name }}</li>
+    <li><strong>Tables</strong>: {{ group.tables }} table{{ group.tables|pluralize }} (${{ group.table_cost|round(2) }}) </li>
+    <li><strong>Badges</strong>: {{ group.badges }} badge{{ group.badges|pluralize }} (${{ group.badge_cost|round(2) }}) </li>
+    <li><strong>Total Price</strong> ${{ group.cost }}</li>
+    <li><strong>What do you sell?</strong> {{ group.wares }}</li>
+    <li><strong>Description</strong>: {{ group.description }}</li>
+    {% if group.special_needs %}<li><strong>Table Requests and Special Requests</strong>: {{ group.special_needs }}</li>{% endif %}
+    <li><strong>Website URL</strong>: {{ group.website }}</li>
+    <li><strong>Address</strong>: {{ group.address1 }}{% if group.address2 %}, {{ group.address2 }}{% endif %}
+    <br/> {{ group.city }}, {{ group.region }} {{ group.zip_code }} ({{ group.country }})</li>
+</ul>
+
+{% if c.DEALER_REG_SOFT_CLOSED %}
+Because our marketplace is currently full, your submission has been automatically placed on our waitlist.  We'll let you know whether or not
+your application is later approved.
+{% else %}
+We will review your request and provide you with a payment link if your application is approved; otherwise,
+you will receive a waitlist or declined email.
+{% endif %}
+
+<br/><br/>Vendor applications automatically reserve the ability to purchase badges for you and the number of assistants on the
+application at the lowest possible pre-registration price available at the date of this application based on available promo codes, 
+if this application is not approved. PLEASE DO NOT BUY A BADGE IF YOU APPLIED FOR A MARKETPLACE SPOT. You will be able to purchase
+badges after a determination has been made on your application. 
+
+{% if group.requested_hotel_info and c.PREREG_REQUEST_HOTEL_INFO_OPEN -%}
+    <br/> <br/>
+    {% include "preregistration/hotel_disclaimer.html" %}
+{%- endif %}
+
+<br/> <br/> <u>Dealer Rules and Information</u>
+{% include "static_views/dealerRules.html" %}
+
+</body>
+</html>

--- a/magwest/templates/preregistration/dealer_confirmation.html
+++ b/magwest/templates/preregistration/dealer_confirmation.html
@@ -1,0 +1,42 @@
+{% extends "./preregistration/preregbase.html" %}
+{% block title %}Dealer Application Received{% endblock %}
+{% block backlink %}{% endblock %}
+{% block content %}
+{% include 'prereg_masthead.html' %}
+<div class="panel panel-default">
+  <div class="panel-body">
+    <h2>{% if group.status == c.WAITLISTED %}You've been added to our waitlist!{% else %}Thanks for applying as a Dealer!{% endif %}</h2>
+
+    We've received your application for {{ group.name }} to purchase a Dealer registration for {{ c.EVENT_NAME }}.
+
+    <br/><br/>
+    {% if group.status == c.WAITLISTED %}
+        Since the Marketplace is currently full, you've been added to our waitlist, and we'll let you know if a spot opens up for you.
+    {% else %}
+        We receive a flood of applications every year, so application processing takes a considerable amount of time.
+        Approvals will be done as promptly as possible; usually no later than <strong>two months</strong> before the event.
+    {% endif %}
+
+    <h3>What Happens Next</h3>
+    After approval, you will be emailed a link to manage your dealer registration. From this link, you will be able to:
+    <ul>
+        <li>Pay for your dealer registration, which includes the cost of tables and badges.</li>
+        <li>Register your Dealer Assistants.</li>
+        <li>After your badge and table payment is received, you may add and pay for additional Dealer Assistants.</li>
+    </ul>
+
+    Your Dealership Payment includes your table cost and all badges in your group.  After payment, you'll be sent a link
+    by email to follow if you wish to later upgrade your badge. Your Dealer Assistants will be able to upgrade their own
+    badges and pay for those upgrades on their own.
+
+    <br/><br/>Later, you will receive another email with more specific information about this year's event.
+
+    <br/><br/>In the event we cannot accommodate your Dealership, you will receive an email. If your application
+    is not approved, you will be able to purchase badges for yourself and the number of assistants on the application
+    at the lowest possible pre-registration price available at the date of this application based on available promo codes. 
+    You will receive an email when these badges are available for purchase.
+
+    {% include "preregistration/disclaimers.html" %}
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
Given that West is using promo codes to determine pricing, we needed to change the final paragraph in this file to reflect the "lowest possible pre-registration price" rather than actually using {c.BADGE_PRICE}, since that price is always $75, and isn't a discount at all.

(I'm pretty sure creating this file overrides ubersystem/uber/templates/preregistration/dealer_confirmation.html, but let me know if that's not true)

(Also going to add a file for the email template for the application confirmation.)