### PR TITLE
Hide "more tables" text just for MAGWest

### DIFF
--- a/magwest/templates/groupform.html
+++ b/magwest/templates/groupform.html
@@ -1,0 +1,9 @@
+<script type="text/javascript">
+  $(function () {
+    if ($("#moretables").length) {
+            // Hide reference to requesting more than four tables
+            $("#moretables").hide();
+        }
+  });
+</script>
+{{ super() }}


### PR DESCRIPTION
This is what we should have done in the first place rather than removing the text in the main plugin.