### PR TITLE
Remove extra deadline from volunteer shirt checklist item

### DIFF
--- a/magwest/templates/signups/shirt_item.html
+++ b/magwest/templates/signups/shirt_item.html
@@ -11,8 +11,5 @@
     {% if attendee.gets_staff_shirt %}
         and your preference of staff or event shirt
     {% endif %}
-    {% if c.SHIRT_DEADLINE %}
-        <b>no later than {{ c.SHIRT_DEADLINE|datetime_local }}</b>
-    {% endif %}
     so that we can set aside shirts in the right sizes at our merch booth. (Deadline: July 31, 2019)
 </li>


### PR DESCRIPTION
We're giving people an extra day on top of SHIRT_DEADLINE, so we need to remove it from the text for West