### PR TITLE
Volunteer Agreement Spacing Fix

### DIFF
--- a/magwest/templates/signups/volunteer_agreement.html
+++ b/magwest/templates/signups/volunteer_agreement.html
@@ -32,7 +32,7 @@ unless approved in writing in advance by the Company. </p>
 Volunteer shall receive the following Perks determined by the amount of Services provided by the Volunteer::<br/>
 (a) a Volunteer that achieves eight (8) hours of Services will be entitled a {{ c.EVENT_NAME }} t-shirt;<br/>
 (b) a Volunteer that achieves sixteen (16) hours of Services will be entitled to access to meals provided by the Company;<br/>
-(c) a Volunteer that achieves twenty-four (24) hours of Services will be entitled to reimbursement of the amount, if any, Volunteer paid for Volunteer's {{ c.EVENT_NAME }} badge; and
+(c) a Volunteer that achieves twenty-four (24) hours of Services will be entitled to reimbursement of the amount, if any, Volunteer paid for Volunteer's {{ c.EVENT_NAME }} badge; and<br/>
 (d) a Volunteer that achieves thirty (30) hours of Services at this {{ c.EVENT_NAME }} and provided Services at one of the Company's previous events will be entitled to shared space in one of the Company's staff hotel rooms for this {{ c.EVENT_NAME }}.<br/>
 
 Other than the aforesaid amounts Volunteer acknowledges and agrees he/she is not entitled to any compensation of any type from {{ c.EVENT_NAME }}.</p>


### PR DESCRIPTION
Forgot one line break between (c) and (d) on the Volunteer Agreement.