### PR TITLE
Update regextra to work with new modular fields

### DIFF
--- a/magwest/templates/regextra.html
+++ b/magwest/templates/regextra.html
@@ -1,13 +1,13 @@
 <script>
-    if (window.BADGE_TYPES) {
-        window.BADGE_TYPES.options[0].description = 'Allows access to the festival for its duration ({{ c.EPOCH|datetime_local("%b %-d") }}-{{ c.ESCHATON|datetime_local("%b %-d") }}). {{ price_notice("Preregistration",c.PREREG_TAKEDOWN) }}';
-        $(function() {
-            if ($(".badge-type-selector").size()) {
-                $(".badge-type-selector").parents('.form-group').hide();
-            }
-            if ($.field('badge_printed_name').size()) {
-                $.field('badge_printed_name').parents('.form-group').remove();
-            }
-        })
-    }
+  if (window.BADGE_TYPES && window.BADGE_TYPES.options[0]) {
+            window.BADGE_TYPES.options[0].description = 'Allows access to the festival for its duration ({{ c.EPOCH|datetime_local("%b %-d") }}-{{ c.ESCHATON|datetime_local("%b %-d") }}). {{ price_notice("Preregistration",c.PREREG_TAKEDOWN) }}';
+        }
+    $(function() {
+        if ($("#badge-types").size()) {
+            $("#badge-types").hide();
+        }
+        if ($.field('badge_printed_name').size()) {
+            $.field('badge_printed_name').parents('.form-group').remove();
+        }
+    })
 </script>


### PR DESCRIPTION
Changes involving the new modular reg fields broke our overriding Javascript, so this fixes that.