### PR TITLE
Add Swag Reminder Email + Email Refresh

### DIFF
--- a/magwest/automated_emails.py
+++ b/magwest/automated_emails.py
@@ -52,3 +52,13 @@ StopsEmailFixture(
     lambda a: c.SHIFTS_CREATED and a.weighted_hours,
     when=days_before(1, c.FINAL_EMAIL_DEADLINE),
     ident='volunteer_shift_schedule_correction')
+
+
+AutomatedEmailFixture(
+    Attendee, 'Last Chance for MAGWest ' + c.EVENT_YEAR + ' bonus swag!', 'attendee_swag_promo.html',
+    lambda a: (
+        a.can_spam
+        and (a.paid == c.HAS_PAID or a.paid == c.NEED_NOT_PAY or (a.group and a.group.amount_paid)),
+    when=days_before(2, c.EPOCH),
+    sender='MAGWest Merch Team <merch@magwest.org>',
+    ident='magwest_bonus_swag_reminder_last_chance')

--- a/magwest/automated_emails.py
+++ b/magwest/automated_emails.py
@@ -53,12 +53,11 @@ StopsEmailFixture(
     when=days_before(1, c.FINAL_EMAIL_DEADLINE),
     ident='volunteer_shift_schedule_correction')
 
-
 AutomatedEmailFixture(
-    Attendee, 'Last Chance for MAGWest ' + c.EVENT_YEAR + ' bonus swag!', 'attendee_swag_promo.html',
-    lambda a: (
-        a.can_spam
-        and (a.paid == c.HAS_PAID or a.paid == c.NEED_NOT_PAY or (a.group and a.group.amount_paid)),
+    Attendee,
+    'Last Chance for MAGWest {EVENT_YEAR} bonus swag!',
+    'attendee_swag_promo.html',
+    lambda a: a.can_spam and a.badge_status == c.COMPLETED_STATUS and a.amount_extra < c.SEASON_LEVEL,
     when=days_before(2, c.EPOCH),
     sender='MAGWest Merch Team <merch@magwest.org>',
     ident='magwest_bonus_swag_reminder_last_chance')

--- a/magwest/templates/emails/attendee_swag_promo.html
+++ b/magwest/templates/emails/attendee_swag_promo.html
@@ -163,10 +163,10 @@ BT was here and fixed variables; hopefully this is all set? -->
                                             <td align="left" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;" class="padding-copy">
                                               
                                               <p>
-                                                <strong>Hey there {{ attendee.first_name}}!</strong>
+                                                <strong>Hey there {{ attendee.first_name }}!</strong>
                                               </p>
 <p>
-Thank you so much for registering to attend {{ c.EVENT_NAME }} {{ c.EVENT_YEAR }}!<br><br>
+Thank you so much for registering to attend {{ c.EVENT_NAME_AND_YEAR }}!<br><br>
 
 When you registered, you had the option to also pre-order extra swag items, most of which are typically offered exclusively during pre-registration. This year, we're letting you order as long as supplies last! If you've already purchased something, you can check out what you've got so far upgrade your swag tier if you'd like using this
     <a href="{{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }}">personalized registration update link</a>.

--- a/magwest/templates/emails/attendee_swag_promo.html
+++ b/magwest/templates/emails/attendee_swag_promo.html
@@ -174,6 +174,14 @@ When you registered, you had the option to also pre-order extra swag items, most
 <p>
 If you're interested, take a look below and make your choice soon. Quantities are <i>extremely limited</i>, and we're close to selling out!
 </p>
+<table width="100%" border="0" cellspacing="0" cellpadding="0" class="mobile-button-container">
+                                        <tr>
+                                            <td align="center" style="padding: 25px 0 0 0;" class="padding-copy">
+                                                <table border="0" cellspacing="0" cellpadding="0" class="responsive-table">
+                                                    <tr>
+                                                        <td align="center"><a href="{{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }}" target="_blank" style="font-size: 16px; font-family: Helvetica, Arial, sans-serif; font-weight: normal; color: #ffffff; text-decoration: none; background-color: #256F9C; border-top: 15px solid #256F9C; border-bottom: 15px solid #256F9C; border-left: 25px solid #256F9C; border-right: 25px solid #256F9C; border-radius: 3px; -webkit-border-radius: 3px; -moz-border-radius: 3px; display: inline-block;" class="mobile-button">Buy Your Swag Now! &rarr;</a></td>
+                                                    </tr>
+                                                </table>						    
 </td>
 </tr>
 <tr >
@@ -189,7 +197,7 @@ If you're interested, take a look below and make your choice soon. Quantities ar
 Get yourself an event t-shirt to commemorate this year's theme! Our shirts are made of 100% some-kind-of-cloth and fit like most shirts fit in the size you wear! We promise that if you buy it, you'll wear it at some point. PLUS this package also comes with a BUTTON. It's sweet.
     </p>
     <p>
-      <img src="https://images.squarespace-cdn.com/content/v1/5b89bad03e2d0969b9ab7ad2/1555640582759-8RL6HEONJZT7RF36UQMR/ke17ZwdGBToddI8pDm48kLkXF2pIyv_F2eUT9F60jBl7gQa3H78H3Y0txjaiv_0fDoOvxcdMmMKkDsyUqMSsMWxHk725yiiHCCLfrh8O1z4YTzHvnKhyp6Da-NYroOW3ZGjoBKy3azqku80C789l0pE4cef1KNtWo36k-CFnr6wOF2g5O-PFkVuvW_ba6dQUZZpzEt6WQHHQe4EHY-NJIA/T-Shirt_Tier_West.png" alt="T-Shirt Tier" width="600"/>
+      <img src="https://images.squarespace-cdn.com/content/v1/5b89bad03e2d0969b9ab7ad2/1567480290361-FIBGOMS6BI5HXPBX6VZP/ke17ZwdGBToddI8pDm48kLkXF2pIyv_F2eUT9F60jBl7gQa3H78H3Y0txjaiv_0fDoOvxcdMmMKkDsyUqMSsMWxHk725yiiHCCLfrh8O1z4YTzHvnKhyp6Da-NYroOW3ZGjoBKy3azqku80C789l0pE4cef1KNtWo36k-CFnr6wOF2g5O-PFkVuvW_ba6dQUZZpzEt6WQHHQe4EHY-NJIA/image-asset.png" alt="T-Shirt Tier" width="600"/>
     </p>
   </td>
 </tr>
@@ -210,10 +218,7 @@ Get yourself an event t-shirt to commemorate this year's theme! Our shirts are m
     <p>
       <strong><center>Mayor Tier Package</center></strong>
       </p><p>
-      This is a <strong>big deal</strong>. You can finally decorate your house to the max with these totally unique items! Start off your morning with a premium roast of Roostart Roaster's Coffee, a beautiful blend of caramel and chocolate in your very own MAGWest mug. 14 oz is a lot to drink at once, so set it on your new set of wooden coasters while you enjoy the whole cup. Caffeine doesn't last forever, though, and eventually you'll want to rest your weary eyes; why not use your fantastic new MAGWest throw pillow and blanket to treat yourself to a little nap? When you wake up, start the process all over again, or use all the items from your previous tiers to maximize your fun!
-    </p>
-    <p>
-      <img src="#" alt="" width="600"/>
+      This is a <strong>big deal</strong>. You can finally decorate your house to the max with these totally unique items! Start off your morning with our very own Roostart Roaster's Coffee, a beautiful blend of caramel and chocolate in your new MAGWest mug. 14 oz is a lot to drink at once, so set it on your new set of wooden coasters while you enjoy the whole cup. Caffeine doesn't last forever, though, and eventually you'll want to rest your weary eyes; why not use your fantastic new MAGWest throw pillow and sherpa blanket to treat yourself to a little nap? When you wake up, start the process all over again, or use all the items from your previous tiers to maximize your fun! All of this plus more surprises are in store for this tier!
     </p>
   </td>
 </tr>

--- a/magwest/templates/emails/attendee_swag_promo.html
+++ b/magwest/templates/emails/attendee_swag_promo.html
@@ -1,0 +1,254 @@
+<!-- email has hardcoded dates for Magfest 2016, TODO: make this email more generic. NONE SHOULD BE HERE -Dom 
+BT was here and fixed variables; hopefully this is all set? -->
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<title>Last Chance to Secure Your MAGWest Kick-In Swag!</title>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+<style type="text/css">
+    /* CLIENT-SPECIFIC STYLES */
+    #outlook a{padding:0;} /* Force Outlook to provide a "view in browser" message */
+    .ReadMsgBody{width:100%;} .ExternalClass{width:100%;} /* Force Hotmail to display emails at full width */
+    .ExternalClass, .ExternalClass p, .ExternalClass span, .ExternalClass font, .ExternalClass td, .ExternalClass div {line-height: 100%;} /* Force Hotmail to display normal line spacing */
+    body, table, td, a{-webkit-text-size-adjust:100%; -ms-text-size-adjust:100%;} /* Prevent WebKit and Windows mobile changing default text sizes */
+    table, td{mso-table-lspace:0pt; mso-table-rspace:0pt;} /* Remove spacing between tables in Outlook 2007 and up */
+    img{-ms-interpolation-mode:bicubic;} /* Allow smoother rendering of resized image in Internet Explorer */
+
+    /* RESET STYLES */
+    body{margin:0; padding:0;}
+    img{border:0; height:auto; line-height:100%; outline:none; text-decoration:none;}
+    table{border-collapse:collapse !important;}
+    body{height:100% !important; margin:0; padding:0; width:100% !important;}
+
+    /* iOS BLUE LINKS */
+    .appleBody a {color:#68440a; text-decoration: none;}
+    .appleFooter a {color:#999999; text-decoration: none;}
+
+    /* MOBILE STYLES */
+    @media screen and (max-width: 525px) {
+
+        /* ALLOWS FOR FLUID TABLES */
+        table[class="wrapper"]{
+          width:100% !important;
+        }
+
+        /* ADJUSTS LAYOUT OF LOGO IMAGE */
+        td[class="logo"]{
+          text-align: left;
+          padding: 20px 0 20px 0 !important;
+        }
+
+        td[class="logo"] img{
+          margin:0 auto!important;
+        }
+
+        /* USE THESE CLASSES TO HIDE CONTENT ON MOBILE */
+        td[class="mobile-hide"]{
+          display:none;}
+
+        img[class="mobile-hide"]{
+          display: none !important;
+        }
+
+        img[class="img-max"]{
+          max-width: 100% !important;
+          width: 100% !important;
+          height:auto !important;
+        }
+
+        /* FULL-WIDTH TABLES */
+        table[class="responsive-table"]{
+          width:100%!important;
+        }
+
+        /* UTILITY CLASSES FOR ADJUSTING PADDING ON MOBILE */
+        td[class="padding"]{
+          padding: 10px 5% 15px 5% !important;
+        }
+
+        td[class="padding-copy"]{
+          padding: 10px 5% 10px 5% !important;
+          text-align: center;
+        }
+
+        td[class="padding-meta"]{
+          padding: 30px 5% 0px 5% !important;
+          text-align: center;
+        }
+
+        td[class="no-pad"]{
+          padding: 0 0 20px 0 !important;
+        }
+
+        td[class="no-padding"]{
+          padding: 0 !important;
+        }
+
+        td[class="section-padding"]{
+          padding: 50px 15px 50px 15px !important;
+        }
+
+        td[class="section-padding-bottom-image"]{
+          padding: 50px 15px 0 15px !important;
+        }
+
+        /* ADJUST BUTTONS ON MOBILE */
+        td[class="mobile-wrapper"]{
+            padding: 10px 5% 15px 5% !important;
+        }
+
+        table[class="mobile-button-container"]{
+            margin:0 auto;
+            width:100% !important;
+        }
+
+        a[class="mobile-button"]{
+            width:80% !important;
+            padding: 15px !important;
+            border: 0 !important;
+            font-size: 16px !important;
+        }
+
+    }
+</style>
+</head>
+<body style="margin: 0; padding: 0;">
+
+<!-- HEADER -->
+<table border="0" cellpadding="0" cellspacing="0" width="100%">
+    <tr>
+        <td bgcolor="#333333">
+            <!-- HIDDEN PREHEADER TEXT -->
+            <div style="display: none; font-size: 1px; color: #fefefe; line-height: 1px; font-family: Helvetica, Arial, sans-serif; max-height: 0px; max-width: 0px; opacity: 0; overflow: hidden;">
+                Supporter swag stocks are running low! Last chance to secure yours.
+            </div>
+            <div align="center" style="padding: 0px 15px 0px 15px;">
+                <table border="0" cellpadding="0" cellspacing="0" width="500" class="wrapper">
+                    <!-- LOGO/PREHEADER TEXT -->
+                    <tr>
+                        <td style="padding: 20px 0px 30px 0px;" class="logo">
+                            <table border="0" cellpadding="0" cellspacing="0" width="100%">
+                                <tr>
+                                    <td bgcolor="#333333" width="100" align="center">
+                                        <a href="https://magwest.org" target="_blank">
+                                            <img alt="MAGFest" src="https://static1.squarespace.com/static/5b89bad03e2d0969b9ab7ad2/t/5b89c838f950b762c9bfe8ca/1567151602586/?format=1500w" width="300" height="80" style="display: block; font-family: Helvetica, Arial, sans-serif; color: #ffffff; font-size: 16px;" border="0">
+                                        </a>
+                                    </td>
+                                </tr>
+                            </table>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+        </td>
+    </tr>
+</table>
+
+<!-- ONE COLUMN SECTION -->
+<table border="0" cellpadding="0" cellspacing="0" width="100%">
+    <tr>
+        <td bgcolor="#ffffff" align="center" style="padding: 20px 15px 70px 15px;" class="section-padding">
+            <table border="0" cellpadding="0" cellspacing="0" width="500" class="responsive-table">
+                <tr>
+                    <td>
+                                    <!-- COPY -->
+                                    <table width="100%" border="0" cellspacing="0" cellpadding="0">
+                                        <tr>
+                                            <td align="center" style="font-size: 25px; font-family: Helvetica, Arial, sans-serif; color: #333333; padding-top: 0px;" class="padding-copy">Last Chance to Secure Your MAGWest Swag!</td>
+                                        </tr>
+                                        <tr>
+                                            <td align="left" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;" class="padding-copy">
+                                              
+                                              <p>
+                                                <strong>Hey there {{ attendee.first_name}}!</strong>
+                                              </p>
+<p>
+Thank you so much for registering to attend {{ c.EVENT_NAME }} {{ c.EVENT_YEAR }}!<br><br>
+
+When you registered, you had the option to also pre-order extra swag items, most of which are typically offered exclusively during pre-registration. This year, we're letting you order as long as supplies last! If you've already purchased something, you can check out what you've got so far upgrade your swag tier if you'd like using this
+    <a href="{{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }}">personalized registration update link</a>.
+</p>
+<p>
+If you're interested, take a look below and make your choice soon. Quantities are <i>extremely limited</i>, and we're close to selling out!
+</p>
+</td>
+</tr>
+<tr >
+  <td align="center" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;" class="padding-copy">
+    <em>(Previews may differ from the final product)</em>
+  </td>
+</tr>
+<tr>
+  <td style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;" class="padding-copy">
+    <p>
+      <strong><center>T-Shirt Package</center></strong></p>
+	  <p>
+Get yourself an event t-shirt to commemorate this year's theme! Our shirts are made of 100% some-kind-of-cloth and fit like most shirts fit in the size you wear! We promise that if you buy it, you'll wear it at some point. PLUS this package also comes with a BUTTON. It's sweet.
+    </p>
+    <p>
+      <img src="https://images.squarespace-cdn.com/content/v1/5b89bad03e2d0969b9ab7ad2/1555640582759-8RL6HEONJZT7RF36UQMR/ke17ZwdGBToddI8pDm48kLkXF2pIyv_F2eUT9F60jBl7gQa3H78H3Y0txjaiv_0fDoOvxcdMmMKkDsyUqMSsMWxHk725yiiHCCLfrh8O1z4YTzHvnKhyp6Da-NYroOW3ZGjoBKy3azqku80C789l0pE4cef1KNtWo36k-CFnr6wOF2g5O-PFkVuvW_ba6dQUZZpzEt6WQHHQe4EHY-NJIA/T-Shirt_Tier_West.png" alt="T-Shirt Tier" width="600"/>
+    </p>
+  </td>
+</tr>
+<tr>
+    <td style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;" class="padding-copy">
+    <p>
+      <strong><center>Supporter Package</center></strong></p>
+      <p>
+            Our supporter pack contains so many sweet items that you'll be so sorry if you miss out. In addition to the t-shirt tier items, you'll get a bunch more stuff to enjoy your day. Put your badge on a crazy custom lanyard, put stickers on your favorite things, and walk around the event with a balloon to raise everyone's spirits, and wear that t-shirt with pride. Relax out by the pool with some MAGWest sunglasses and a branded beach ball, and cool yourself down with an electric fan. Then, when it's sleepy time, put on your Li'l Bandit Sleep Mask for some precious recharging. Carry it all with you in a beautiful dye-sub bag!
+    </p>
+    <p>
+      <img src="https://images.squarespace-cdn.com/content/v1/5b89bad03e2d0969b9ab7ad2/1564615461872-Z116LGCEI63PVFETDHSY/ke17ZwdGBToddI8pDm48kPqQfq0L3n3wpHIsRapTfg8UqsxRUqqbr1mOJYKfIPR7LoDQ9mXPOjoJoqy81S2I8N_N4V1vUb5AoIIIbLZhVYxCRW4BPu10St3TBAUQYVKcpZFgonhpUjQuR9UY_f4FRv01MfGGW-Q2SKIZAaCvwbmMH1mhS07BCLTJvtZLtrKj/unnamed.png" alt="Supporter Package" width="600"/>
+    </p>
+  </td>
+</tr>
+<tr>
+    <td style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;" class="padding-copy">
+    <p>
+      <strong><center>Mayor Tier Package</center></strong>
+      </p><p>
+      This is a <strong>big deal</strong>. You can finally decorate your house to the max with these totally unique items! Start off your morning with a premium roast of Roostart Roaster's Coffee, a beautiful blend of caramel and chocolate in your very own MAGWest mug. 14 oz is a lot to drink at once, so set it on your new set of wooden coasters while you enjoy the whole cup. Caffeine doesn't last forever, though, and eventually you'll want to rest your weary eyes; why not use your fantastic new MAGWest throw pillow and blanket to treat yourself to a little nap? When you wake up, start the process all over again, or use all the items from your previous tiers to maximize your fun!
+    </p>
+    <p>
+      <img src="#" alt="" width="600"/>
+    </p>
+  </td>
+</tr>
+
+<tr>
+  <td align="center" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;" class="padding-copy">
+Ordering these items now is the only way to guarantee them! If we sell out, they're gone for good, and you'll spend the rest of your life wondering how you could've let this opportunity slip away from you. Living with regret is tough, and we're just trying to help you do what's right for you and your future-self.
+</td>
+                                        </tr>
+                                    </table>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td align="center">
+                                    <!-- BULLETPROOF BUTTON -->
+                                    <table width="100%" border="0" cellspacing="0" cellpadding="0" class="mobile-button-container">
+                                        <tr>
+                                            <td align="center" style="padding: 25px 0 0 0;" class="padding-copy">
+                                                <table border="0" cellspacing="0" cellpadding="0" class="responsive-table">
+                                                    <tr>
+                                                        <td align="center"><a href="{{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }}" target="_blank" style="font-size: 16px; font-family: Helvetica, Arial, sans-serif; font-weight: normal; color: #ffffff; text-decoration: none; background-color: #256F9C; border-top: 15px solid #256F9C; border-bottom: 15px solid #256F9C; border-left: 25px solid #256F9C; border-right: 25px solid #256F9C; border-radius: 3px; -webkit-border-radius: 3px; -moz-border-radius: 3px; display: inline-block;" class="mobile-button">Buy Your Swag Now! &rarr;</a></td>
+                                                    </tr>
+                                                </table>
+                                            </td>
+                                        </tr>
+                                    </table>
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+
+</body>
+</html>

--- a/magwest/templates/emails/guest_food_info.txt
+++ b/magwest/templates/emails/guest_food_info.txt
@@ -1,17 +1,14 @@
 {{ attendee.first_name }},
-Thanks again for coming out to {{ c.EVENT_NAME }} as a Guest! As we've previously mentioned, we feed our guests three meals per day during {{ c.EVENT_NAME }}, so you can drop by the Hospitality Suite in Room 5217 on the 5th floor of the hotel for snacks at any time and for food during any of the following times:
+Thanks again for coming out to {{ c.EVENT_NAME }} as a Guest! We have limited meals and snacks available during {{ c.EVENT_NAME }}, so you can drop by the Tea Room or Staff Suite in the San Simeon or San Martin rooms located in the staff only area behind the panels rooms at anytime during {{ c.EVENT_NAME }} for a snack or drink. 
 
-Breakfast: 8:00 am to 11:00 am
-Lunch: 12:00 pm to 3:00 pm
-Dinner: 5:00 pm to 9:00 pm
-SUITE IS OPEN 24/7 WITH SNACKS & GRAB AND GO
+Catered meals will be served at the following times in the Staff Suite (San Martin):
+Breakfast: 11:00 am
+Dinner: 5:00 pm
+These meals are served first-come first-served and in limited quantity.
 
-The first meal served will be breakfast on Thursday morning, and the suite will remain open through Sunday afternoon. Sunday will have a breakfast option, but once breakfast is over, leftovers will be served. You will be able to help yourself. Please feel free to bring tupperware or storage bags to carry items home. You will be responsible for their proper storage.
-
-Meal schedule, menu, and suite rules can all be found at staffsuite.magfe.st
+Snacks, tea, and small meals are available 24/7 in the Tea Room (San Simeon).
 
 Please let us know if you have any questions.
 
-MAGFest Staff Suite
-chefs@magfest.org
-staffsuite.magfe.st
+MAGWest Staff Suite
+tearoom@magwest.org

--- a/magwest/templates/emails/prefest_faq.html
+++ b/magwest/templates/emails/prefest_faq.html
@@ -1,4 +1,8 @@
-If you are receiving this, you are registered for <a href="http://magwest.org">{{ c.EVENT_NAME }}</a>, occurring September 13-15. This FAQ should answer most of your questions about the event. You may reach us at <a href="mailto:contact@magwest.org">contact@magwest.org</a> for any questions not covered here.
+Hey there!<br><br>
+If you are receiving this, you are registered for <a href="https://magwest.org">{{ c.EVENT_NAME }}</a>, occurring September 13-15. This FAQ should answer most of your questions about the event. You may reach us at <a href="mailto:contact@magwest.org">contact@magwest.org</a> for any questions not covered here.
+<br><br>
+All attendees are expected to adhere to the <a href="https://www.magwest.org/code-of-conduct">code of conduct</a> and follow all rules/directions from staff.<br>
+If you're interested in LAN, please make sure you review the <a href="https://magwest.squarespace.com/lan-rules">LAN rules</a>.
 <br><br>
 <b> Will badges be sold at the door?</b>
 Yes. Full three-day weekend badges will be available for $75, and one day badges will be available for $35 for Friday, $45 for Saturday, and $20 for Sunday. Children 5 & under are free, and children 12 & under receive a discount equal to half of the current badge price (available for weekend badges only). We may sell out of one day badges at the door, so if you have friends who haven't gotten their MAGWest badge yet, encourage them to grab a weekend badge now and secure their spot.
@@ -13,7 +17,7 @@ The first step is to go to the registration desk located near the stairway conve
 After you've picked up your badge, you can pick up your swag at the MAGWest Merch booth. The merch booth is located within the Marketplace. Consult our schedule for Marketplace/Merch hours.
 <br><br>
 <b>Am I still able to purchase kick-in swag?</b>
-Yes! Quantities are <i>extremely</i> limited, so you'll need to make your way to the MAGWest Merch booth in the Marketplace as soon as possible! If you want to make sure you secure your swag before the event, you can return to your badge info page and upgrade your badge.
+Yes! Quantities are <i>extremely</i> limited, so you'll need to make your way to the MAGWest Merch booth in the Marketplace as soon as possible! If you want to make sure you secure your swag before the event, you can return to your badge info page (see your badge confirmation email) and upgrade your badge.
 <br><br>
 <b>Where can I view a schedule of events?</b>
 <i>Visit the MAGWest website</i>: Go to the MAGWest <a href="http://magwest.org" target="_blank">website</a> and click Schedule at the top right or use the following link to go straight to the <a href="https://magwest2019.sched.com/" target="_blank">MAGWest 2019 schedule.</a>
@@ -25,3 +29,5 @@ Use <a href="https://west2019.reggie.magfest.org/uber/preregistration/check_if_p
 We do not provide refunds, but we do allow you to sell or transfer your badge to anyone you wish. E-mail <a href="mailto:regsupport@magfest.org">regsupport@magfest.org</a> from the original e-mail address you registered with (or provide the original e-mail) along with your full name, and we will send you a link to transfer your badge as soon as we can.
 <br><br>
 <b>Only questions about badge transfers, badge confirmations, or general registration questions should be e-mailed to the registration desk e-mail address. We are unable to respond to any other inquiries.</b>
+<br><br>
+We're so excited to see you!

--- a/magwest/templates/emails/prefest_faq.html
+++ b/magwest/templates/emails/prefest_faq.html
@@ -23,7 +23,7 @@ Yes! Quantities are <i>extremely</i> limited, so you'll need to make your way to
 <i>Visit the MAGWest website</i>: Go to the MAGWest <a href="http://magwest.org" target="_blank">website</a> and click Schedule at the top right or use the following link to go straight to the <a href="https://magwest2019.sched.com/" target="_blank">MAGWest 2019 schedule.</a>
 <br><br>
 <b>Can I check if I'm pre-registered?</b>
-Use <a href="https://west2019.reggie.magfest.org/uber/preregistration/check_if_preregistered">this page</a> to check your registration status.
+Use <a href="{{ c.URL_BASE }}/preregistration/check_if_preregistered">this page</a> to check your registration status.
 <br><br>
 <b>Do you provide refunds or badge transfers?</b>
 We do not provide refunds, but we do allow you to sell or transfer your badge to anyone you wish. E-mail <a href="mailto:regsupport@magfest.org">regsupport@magfest.org</a> from the original e-mail address you registered with (or provide the original e-mail) along with your full name, and we will send you a link to transfer your badge as soon as we can.

--- a/magwest/templates/emails/prefest_faq.html
+++ b/magwest/templates/emails/prefest_faq.html
@@ -11,7 +11,7 @@ Yes. Full three-day weekend badges will be available for $75, and one day badges
 The Doubletree by Hilton offers day/overnight parking for $18 in their parking lot per day. Parking on the street is not allowed, and parking at the nearby business parks is not allowed for hotel visitors.
 <br><br>
 <b>Where do I go when I arrive? How do I pick up my badge?</b>
-The first step is to go to the registration desk located near the stairway convention center entrance of the DoubleTree to pick up your badge. The registration desk is open from 9:00 AM to 12:00 AM Friday and Saturday, and 9:00 AM to 12:00 PM Sunday. If you pre-registered, simply show photo ID such as a driver's license, military ID, or student ID to the registration staffers. If you do not have a photo ID, print out the confirmation e-mail you received when you pre-registered.
+Once you're at the DoubleTree, follow signs to Registration to pick up your badge. The registration desk is open from 9:00 AM to 12:00 AM Friday and Saturday, and 9:00 AM to 12:00 PM Sunday. If you pre-registered, simply show photo ID such as a driver's license, military ID, or student ID to the registration staffers. If you do not have a photo ID, print out the confirmation e-mail you received when you pre-registered.
 <br><br>
 <b>Where can I pick up swag that I pre-ordered, such as a t-shirt or supporter bundle?</b>
 After you've picked up your badge, you can pick up your swag at the MAGWest Merch booth. The merch booth is located within the Marketplace. Consult our schedule for Marketplace/Merch hours.

--- a/magwest/templates/emails/prefest_faq.html
+++ b/magwest/templates/emails/prefest_faq.html
@@ -1,29 +1,27 @@
-If you are receiving this, you are registered for <a href="http://magwest.org">{{ c.EVENT_NAME }}</a>, occurring August 10th-12th, 2018. This FAQ should answer most of your questions about the event. You may reach us at contact@magwest.org for any questions not covered here.
+If you are receiving this, you are registered for <a href="http://magwest.org">{{ c.EVENT_NAME }}</a>, occurring September 13-15. This FAQ should answer most of your questions about the event. You may reach us at <a href="mailto:contact@magwest.org">contact@magwest.org</a> for any questions not covered here.
 <br><br>
 <b> Will badges be sold at the door?</b>
-Yes. Full three-day weekend badges will be available for $80, and one day badges will be available for $45 for Friday, $50 for Saturday, and $25 for Sunday. Children 5 & under are free, and children 12 & under receive a discount equal to half of the current badge price (available for weekend badges only). We may sell out of one day badges at the door, so if you have friends who haven't gotten their MAGWest badge yet, encourage them to grab a weekend badge now and secure their spot.
+Yes. Full three-day weekend badges will be available for $75, and one day badges will be available for $35 for Friday, $45 for Saturday, and $20 for Sunday. Children 5 & under are free, and children 12 & under receive a discount equal to half of the current badge price (available for weekend badges only). We may sell out of one day badges at the door, so if you have friends who haven't gotten their MAGWest badge yet, encourage them to grab a weekend badge now and secure their spot.
 <br><br>
 <b>Where can I park for the weekend?</b>
-The Hyatt Regency Santa Clara offers day parking for $15 in the front lot, or for free on the 2nd and 3rd floors of the parking garage located behind the hotel. Overnight parking is $15 per night in either location.
+The Doubletree by Hilton offers day/overnight parking for $18 in their parking lot per day. Parking on the street is not allowed, and parking at the nearby business parks is not allowed for hotel visitors.
 <br><br>
 <b>Where do I go when I arrive? How do I pick up my badge?</b>
-The first step is to go to the registration desk located in the lobby of the Hyatt Regency to pick up your badge. The registration desk is open from 9:00 AM to 12:00 AM Friday and Saturday, and 10:00 AM to 1:00 PM Sunday. If you pre-registered, simply show photo ID such as a driver's license, military ID, or student ID to the registration staffers. If you do not have a photo ID, print out the confirmation e-mail you received when you pre-registered.
-<br><br>
-<b>Which registration line do I use?</b>
-- Attendees who purchased a standard badge should use the "Pre-Registered Badge Pickup" line.
-- Staff, Supporters, Guests, and Panelists should use the line that lists those categories.
-- If you are not already registered for a badge, you can register on your phone and then join the "Pre-Registered Badge Pickup" line, or head to our handy "At-Door Registration" kiosks first.
+The first step is to go to the registration desk located near the stairway convention center entrance of the DoubleTree to pick up your badge. The registration desk is open from 9:00 AM to 12:00 AM Friday and Saturday, and 9:00 AM to 12:00 PM Sunday. If you pre-registered, simply show photo ID such as a driver's license, military ID, or student ID to the registration staffers. If you do not have a photo ID, print out the confirmation e-mail you received when you pre-registered.
 <br><br>
 <b>Where can I pick up swag that I pre-ordered, such as a t-shirt or supporter bundle?</b>
-After you've picked up your badge, you can pick up your swag at the MAGFest merch booth. The merch booth is conveniently co-located with Registration.
+After you've picked up your badge, you can pick up your swag at the MAGWest Merch booth. The merch booth is located within the Marketplace. Consult our schedule for Marketplace/Merch hours.
+<br><br>
+<b>Am I still able to purchase kick-in swag?</b>
+Yes! Quantities are <i>extremely</i> limited, so you'll need to make your way to the MAGWest Merch booth in the Marketplace as soon as possible! If you want to make sure you secure your swag before the event, you can return to your badge info page and upgrade your badge.
 <br><br>
 <b>Where can I view a schedule of events?</b>
-<i>Visit the MAGWest website</i>: Go to the MAGWest <a href="http://magwest.org" target="_blank">website</a> and click Schedule at the top right or use the following link to go straight to the <a href="https://west2018.uber.magfest.org/uber/schedule/" target="_blank">MAGWest 2018 schedule.</a>
+<i>Visit the MAGWest website</i>: Go to the MAGWest <a href="http://magwest.org" target="_blank">website</a> and click Schedule at the top right or use the following link to go straight to the <a href="https://magwest2019.sched.com/" target="_blank">MAGWest 2019 schedule.</a>
 <br><br>
 <b>Can I check if I'm pre-registered?</b>
-Use <a href="https://west2018.uber.magfest.org/uber/preregistration/check_if_preregistered">this page</a> to check your registration status.
+Use <a href="https://west2019.reggie.magfest.org/uber/preregistration/check_if_preregistered">this page</a> to check your registration status.
 <br><br>
 <b>Do you provide refunds or badge transfers?</b>
-We do not provide refunds, but we do allow you to sell or transfer your badge to anyone you wish. E-mail regsupport@magfest.org from the original e-mail address you registered with (or provide the original e-mail) along with your full name, and we will send you a link to transfer your badge as soon as we can.
+We do not provide refunds, but we do allow you to sell or transfer your badge to anyone you wish. E-mail <a href="mailto:regsupport@magfest.org">regsupport@magfest.org</a> from the original e-mail address you registered with (or provide the original e-mail) along with your full name, and we will send you a link to transfer your badge as soon as we can.
 <br><br>
 <b>Only questions about badge transfers, badge confirmations, or general registration questions should be e-mailed to the registration desk e-mail address. We are unable to respond to any other inquiries.</b>

--- a/magwest/templates/emails/volunteer_food_info.txt
+++ b/magwest/templates/emails/volunteer_food_info.txt
@@ -1,30 +1,19 @@
 {{ attendee.first_name }},
 
-Thanks again for volunteering at {{ c.EVENT_NAME }} this year. We feed our volunteers three meals per day during {{ c.EVENT_NAME }}, so you can drop by the Hospitality Suite in Room 5217 on the 5th floor of the hotel for food at anytime during {{ c.EVENT_NAME }} for a snack or drink. Meals will be served at the following times:
+Thanks again for volunteering at {{ c.EVENT_NAME }} this year. We have limited meals and snacks available during {{ c.EVENT_NAME }}, so you can drop by the Tea Room in San Simeon or Staff Suite in San Martin located in the staff only area behind the panels rooms during {{ c.EVENT_NAME }} for a snack or drink. 
 
-Breakfast: 8:00 am to 11:00 am
-Lunch: 12:00 pm to 3:00 pm
-Dinner: 5:00 pm to 9:00 pm
-Overnight: 9:00 pm to 4:00 am (or until the hot food has run out, whichever occurs first)
+Catered meals will be served at the following times in the Staff Suite (San Martin):
+Breakfast: 11:00 am
+Dinner: 5:00 pm
+These meals are served first-come first-served and in limited quantity.
 
-We also have a grab and go station availbale 24/7 with sandwiches, instant oatmeal and ramen. Gluten free options, vegan options and non dairy is available, just ask if you have a restriction! 
+Snacks, tea, and small meals are available 24/7 in the Tea Room (San Simeon)
 
-{% if attendee.badge_type == ATTENDEE_BADGE %}You will become eligible for food after working your first shift if you have signed up for at least 12 weighted hours. Please visit Staffing Ops (in Camelia 1 on the Ballroom level) after you first get your badge to get your shift schedule, and then come back to get your ribbon marked after working your first shift and getting your department head to sign your sheet. You will not be able to get snacks, drinks, or meals, or have food picked up without your volunteer ribbon being properly marked.
+{% if attendee.badge_type == ATTENDEE_BADGE %}You will become eligible for food after working your first shift if you have signed up for at least 12 weighted hours. Please visit Staffing Ops (in the Silicon Valley Room across from the 2F ballrooms) after you first get your badge to get your shift schedule, and then come back to get your ribbon marked after working your first shift and getting your department head to sign your sheet. You will not be able to get snacks, drinks, or meals without your volunteer ribbon being properly marked.
 
-{% endif %}The first meal served will be breakfast on Thursday morning, and the suite will remain open through Sunday afternoon. Monday will have a breakfast option, but once breakfast is over, leftovers will be served. You will be able to help yourself. Please feel free to bring tupperware or storage bags to carry items home. You will be responsible for their proper storage.
-
-You will also have the option to have food picked up for you while on shift. This option is primarily for those staffers and volunteers who are unable to visit the suite during meal service. See your department head to order food to be picked up.
-
-Meal schedule, menu, food pick up process, and suite rules can all be found at http://staffsuite.magfe.st/.
-
-In addition to the Staff Suite, you will be eligible to buy food at the Galaxy Cafe, which is the Gaylord's cafeteria for its own staff which they have generously allowed us to use. To get to the Galaxy Cafe, go to the far back of the Maryland Ballroom foyer, then go through the doors and turn left. Just before you get to the Security desk in the hallway, look to your left and there will be a wide set of stairs going down. Go down those stairs and then the Galaxy Cafe will be on your right. You can use the Galaxy Cafe during any of the following times and is at your own expense:
-
-Breakfast : 6:30 am - 9:30 am
-Lunch/Dinner : 1:00 pm - 11:00 pm
-Overnight : 2:00 am - 4:00 am
+{% endif %}The first meal served will be breakfast on Friday morning, and the suite will remain open through Sunday afternoon.
 
 Please let us know if you have any questions.
 
-MAGFest Staff Suite
-chefs@magfest.org
-http://staffsuite.magfe.st/
+MAGWest Tea Room
+tearoom@magwest.org


### PR DESCRIPTION
Adds automated email for MAGWest swag reminder. Based on super's, except we don't have a deadline, so changed the when condition to basically be 2 days before the start of the event.

Also adding attendee_swag_promo.html.

Additional updates to refresh remaining pending emails (pre-event FAQ, volunteer food emails)