### PR TITLE
Delay swag reminder until 1 day after someone pre-registers

### DIFF
--- a/magwest/automated_emails.py
+++ b/magwest/automated_emails.py
@@ -57,7 +57,8 @@ AutomatedEmailFixture(
     Attendee,
     'Last Chance for MAGWest {EVENT_YEAR} bonus swag!',
     'attendee_swag_promo.html',
-    lambda a: a.can_spam and a.badge_status == c.COMPLETED_STATUS and a.amount_extra < c.SEASON_LEVEL,
+    lambda a: a.can_spam and a.badge_status == c.COMPLETED_STATUS and
+              a.amount_extra < c.SEASON_LEVEL and days_after(1, a.registered)(),
     when=days_before(2, c.EPOCH),
     sender='MAGWest Merch Team <merch@magwest.org>',
     ident='magwest_bonus_swag_reminder_last_chance')


### PR DESCRIPTION
It's a little silly to register and then immediately get an email reminding you that you may want merch.